### PR TITLE
feat: update ansible-deploy action for UpCloud dynamic inventory and SOPS secrets

### DIFF
--- a/.github/actions/ansible-deploy/action.yml
+++ b/.github/actions/ansible-deploy/action.yml
@@ -1,52 +1,98 @@
 name: "Ansible Deploy"
-description: "Deploys an application by checking out a branch, running yarn install and build, and restarting the PM2 service via Ansible."
+description: "Deploys an application via Ansible to UpCloud infrastructure using dynamic inventory and SOPS-encrypted secrets."
 
 inputs:
-  host:
+  environment:
     required: true
-    description: "Server IP to deploy to"
+    description: "Deployment environment (staging or prod)"
   branch:
     required: true
-    description: "Branch to check out and deploy"
+    description: "Branch to deploy"
+  app:
+    required: true
+    description: "UpCloud app label value (e.g. aggregated-public-information)"
   repo_name:
     required: true
-    description: "Repository name — matches the cloned folder name and the PM2 service name"
-  SSH_PRIVATE_KEY:
+    description: "Directory name on server (e.g. aggregated-public-information)"
+  repo_url:
     required: true
-    description: "Deploy SSH private key"
+    description: "SSH clone URL (e.g. git@github.com:distributeaid/aggregated-public-information.git)"
+  infra_checkout_token:
+    required: true
+    description: "GitHub token with read access to distributeaid/infrastructure"
+  upcloud_token:
+    required: true
+    description: "UpCloud API token"
+  ansible_ssh_private_key:
+    required: true
+    description: "SSH private key for Ansible to connect to servers"
+  sops_age_key:
+    required: true
+    description: "Age private key for SOPS secret decryption"
 
 runs:
   using: "composite"
   steps:
-    - name: Set up SSH key
-      shell: bash
-      run: |
-        mkdir -p ~/.ssh
-        echo "${{ inputs.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
-        chmod 600 ~/.ssh/id_ed25519
-        ssh-keyscan -H ${{ inputs.host }} >> ~/.ssh/known_hosts
-
     - name: Checkout infrastructure repo
       uses: actions/checkout@v4
       with:
         repository: distributeaid/infrastructure
-        path: infrastructure
+        token: ${{ inputs.infra_checkout_token }}
 
-    - name: Install Ansible
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+
+    - name: Install Ansible and UpCloud API client
       shell: bash
-      run: pip install ansible
+      run: pip install ansible upcloud-api
 
-    - name: Write dynamic inventory
+    - name: Install Ansible collections
+      shell: bash
+      run: ansible-galaxy collection install -r ansible/requirements.yml
+
+    - name: Install sops
       shell: bash
       run: |
-        cat > /tmp/inventory.ini << EOF
-        [deploy]
-        ${{ inputs.host }} ansible_user=deploy
-        EOF
+        curl -sSfL "https://github.com/getsops/sops/releases/download/v3.9.1/sops-v3.9.1.linux.amd64" \
+          -o /usr/local/bin/sops
+        chmod +x /usr/local/bin/sops
+
+    - name: Install age
+      shell: bash
+      run: |
+        curl -sSfL "https://github.com/FiloSottile/age/releases/download/v1.2.0/age-v1.2.0-linux-amd64.tar.gz" \
+          | tar -xz -C /tmp
+        mv /tmp/age/age /usr/local/bin/age
+
+    - name: Write Ansible SSH private key
+      shell: bash
+      run: |
+        mkdir -p ~/.ssh
+        echo "${{ inputs.ansible_ssh_private_key }}" > ~/.ssh/ansible_deploy
+        chmod 600 ~/.ssh/ansible_deploy
+
+    - name: Write SOPS age key
+      shell: bash
+      run: |
+        mkdir -p ~/.config/sops/age
+        echo "${{ inputs.sops_age_key }}" > ~/.config/sops/age/keys.txt
+        chmod 600 ~/.config/sops/age/keys.txt
 
     - name: Run deploy playbook
       shell: bash
+      env:
+        ANSIBLE_CONFIG: ansible/ansible.cfg
+        UPCLOUD_TOKEN: ${{ inputs.upcloud_token }}
       run: |
-        ansible-playbook infrastructure/ansible/playbooks/deploy.yml \
-          -i /tmp/inventory.ini \
-          --extra-vars "branch=${{ inputs.branch }} repo_name=${{ inputs.repo_name }}"
+        APP_GROUP="${{ inputs.app }}"
+        APP_GROUP="${APP_GROUP//-/_}"
+        ansible-playbook ansible/playbooks/deploy.yml \
+          -i ansible/inventory/upcloud.yml \
+          --limit "env_${{ inputs.environment }}_app_${APP_GROUP}" \
+          --private-key ~/.ssh/ansible_deploy \
+          -e "repo_url=${{ inputs.repo_url }}" \
+          -e "repo_name=${{ inputs.repo_name }}" \
+          -e "branch=${{ inputs.branch }}" \
+          -e "environment=${{ inputs.environment }}"

--- a/.github/actions/ansible-deploy/action.yml
+++ b/.github/actions/ansible-deploy/action.yml
@@ -8,15 +8,9 @@ inputs:
   branch:
     required: true
     description: "Branch to deploy"
-  app:
-    required: true
-    description: "UpCloud app label value (e.g. aggregated-public-information)"
   repo_name:
     required: true
-    description: "Directory name on server (e.g. aggregated-public-information)"
-  repo_url:
-    required: true
-    description: "SSH clone URL (e.g. git@github.com:distributeaid/aggregated-public-information.git)"
+    description: "Repository and app name (e.g. aggregated-public-information) — used for UpCloud label lookup, server directory, and SSH clone URL"
   infra_checkout_token:
     required: true
     description: "GitHub token with read access to distributeaid/infrastructure"
@@ -86,13 +80,13 @@ runs:
         ANSIBLE_CONFIG: ansible/ansible.cfg
         UPCLOUD_TOKEN: ${{ inputs.upcloud_token }}
       run: |
-        APP_GROUP="${{ inputs.app }}"
+        APP_GROUP="${{ inputs.repo_name }}"
         APP_GROUP="${APP_GROUP//-/_}"
         ansible-playbook ansible/playbooks/deploy.yml \
           -i ansible/inventory/upcloud.yml \
           --limit "env_${{ inputs.environment }}_app_${APP_GROUP}" \
           --private-key ~/.ssh/ansible_deploy \
-          -e "repo_url=${{ inputs.repo_url }}" \
+          -e "repo_url=git@github.com:distributeaid/${{ inputs.repo_name }}.git" \
           -e "repo_name=${{ inputs.repo_name }}" \
           -e "branch=${{ inputs.branch }}" \
           -e "environment=${{ inputs.environment }}"

--- a/README.md
+++ b/README.md
@@ -36,17 +36,15 @@ Deploys an application to UpCloud infrastructure via Ansible, using dynamic inve
 
 ### Inputs
 
-| name                    | description                                                                               | required |
-|-------------------------|-------------------------------------------------------------------------------------------|----------|
-| `environment`           | Deployment environment (`staging` or `prod`)                                              | `true`   |
-| `branch`                | Branch to deploy                                                                          | `true`   |
-| `app`                   | UpCloud app label value (e.g. `aggregated-public-information`)                            | `true`   |
-| `repo_name`             | Directory name on server (e.g. `aggregated-public-information`)                           | `true`   |
-| `repo_url`              | SSH clone URL (e.g. `git@github.com:distributeaid/aggregated-public-information.git`)     | `true`   |
-| `infra_checkout_token`  | GitHub token with read access to `distributeaid/infrastructure`                           | `true`   |
-| `upcloud_token`         | UpCloud API token                                                                         | `true`   |
-| `ansible_ssh_private_key` | SSH private key for Ansible to connect to servers                                       | `true`   |
-| `sops_age_key`          | Age private key for SOPS secret decryption                                                | `true`   |
+| name                      | description                                                                                                                          | required |
+|---------------------------|--------------------------------------------------------------------------------------------------------------------------------------|----------|
+| `environment`             | Deployment environment (`staging` or `prod`)                                                                                         | `true`   |
+| `branch`                  | Branch to deploy                                                                                                                     | `true`   |
+| `repo_name`               | Repository and app name (e.g. `aggregated-public-information`) — used for UpCloud label lookup, server directory, and SSH clone URL  | `true`   |
+| `infra_checkout_token`    | GitHub token with read access to `distributeaid/infrastructure`                                                                      | `true`   |
+| `upcloud_token`           | UpCloud API token                                                                                                                    | `true`   |
+| `ansible_ssh_private_key` | SSH private key for Ansible to connect to servers                                                                                    | `true`   |
+| `sops_age_key`            | Age private key for SOPS secret decryption                                                                                           | `true`   |
 
 ### Secrets setup
 
@@ -81,9 +79,7 @@ jobs:
         with:
           environment: ${{ inputs.environment }}
           branch: ${{ inputs.branch }}
-          app: aggregated-public-information
           repo_name: aggregated-public-information
-          repo_url: git@github.com:distributeaid/aggregated-public-information.git
           infra_checkout_token: ${{ secrets.INFRA_CHECKOUT_TOKEN }}
           upcloud_token: ${{ secrets.UPCLOUD_TOKEN }}
           ansible_ssh_private_key: ${{ secrets.ANSIBLE_SSH_PRIVATE_KEY }}

--- a/README.md
+++ b/README.md
@@ -32,18 +32,27 @@ jobs:
 
 ## Ansible Deploy
 
-This GitHub Action deploys an application to a server by checking out the specified branch, running `yarn install` and `yarn build`, and restarting the PM2 service. It connects to the server over SSH using the provided private key.
+Deploys an application to UpCloud infrastructure via Ansible, using dynamic inventory (UpCloud labels) and SOPS-encrypted secrets.
 
 ### Inputs
 
-| name              | description                                                                              | required | default |
-|-------------------|------------------------------------------------------------------------------------------|----------|---------|
-| `host`            | <p>Server IP to deploy to</p>                                                            | `true`   | N/A     |
-| `branch`          | <p>Branch to check out and deploy</p>                                                    | `true`   | N/A     |
-| `repo_name`       | <p>Repository name — matches the cloned folder name and PM2 service name</p>            | `true`   | N/A     |
-| `SSH_PRIVATE_KEY` | <p>Deploy SSH private key</p>                                                            | `true`   | N/A     |
+| name                    | description                                                                               | required |
+|-------------------------|-------------------------------------------------------------------------------------------|----------|
+| `environment`           | Deployment environment (`staging` or `prod`)                                              | `true`   |
+| `branch`                | Branch to deploy                                                                          | `true`   |
+| `app`                   | UpCloud app label value (e.g. `aggregated-public-information`)                            | `true`   |
+| `repo_name`             | Directory name on server (e.g. `aggregated-public-information`)                           | `true`   |
+| `repo_url`              | SSH clone URL (e.g. `git@github.com:distributeaid/aggregated-public-information.git`)     | `true`   |
+| `infra_checkout_token`  | GitHub token with read access to `distributeaid/infrastructure`                           | `true`   |
+| `upcloud_token`         | UpCloud API token                                                                         | `true`   |
+| `ansible_ssh_private_key` | SSH private key for Ansible to connect to servers                                       | `true`   |
+| `sops_age_key`          | Age private key for SOPS secret decryption                                                | `true`   |
 
-### Examples
+### Secrets setup
+
+`INFRA_CHECKOUT_TOKEN` must be a fine-grained PAT with **Contents: Read** on `distributeaid/infrastructure`, stored as an org secret accessible to caller repos.
+
+### Example
 
 ```yaml
 name: Deploy
@@ -51,12 +60,17 @@ name: Deploy
 on:
   workflow_dispatch:
     inputs:
-      host:
+      environment:
+        description: "Deployment environment"
         required: true
-        description: "Server IP"
+        type: choice
+        options:
+          - staging
+          - prod
       branch:
-        required: true
         description: "Branch to deploy"
+        required: true
+        default: main
 
 jobs:
   deploy:
@@ -65,8 +79,13 @@ jobs:
       - name: Deploy application
         uses: distributeaid/centralised-github-actions/.github/actions/ansible-deploy@main
         with:
-          host: ${{ inputs.host }}
+          environment: ${{ inputs.environment }}
           branch: ${{ inputs.branch }}
+          app: aggregated-public-information
           repo_name: aggregated-public-information
-          SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+          repo_url: git@github.com:distributeaid/aggregated-public-information.git
+          infra_checkout_token: ${{ secrets.INFRA_CHECKOUT_TOKEN }}
+          upcloud_token: ${{ secrets.UPCLOUD_TOKEN }}
+          ansible_ssh_private_key: ${{ secrets.ANSIBLE_SSH_PRIVATE_KEY }}
+          sops_age_key: ${{ secrets.SOPS_AGE_KEY }}
 ```


### PR DESCRIPTION
## Summary

- Replaces the old static-host / PM2 approach with the new UpCloud dynamic inventory + SOPS/age flow
- New inputs: `environment`, `app`, `repo_url`, `infra_checkout_token`, `upcloud_token`, `ansible_ssh_private_key`, `sops_age_key`
- Checks out `distributeaid/infrastructure` explicitly using `infra_checkout_token` so Ansible playbooks and inventory are always available
- Updates README with new input table and usage example

## Migration for caller repos

Replace the `uses: distributeaid/infrastructure/.github/workflows/deploy.yml@main` reusable workflow call with a job that uses this composite action directly:

```yaml
jobs:
  deploy:
    runs-on: ubuntu-latest
    steps:
      - uses: distributeaid/centralised-github-actions/.github/actions/ansible-deploy@main
        with:
          environment: ${{ inputs.environment }}
          branch: ${{ inputs.branch }}
          app: your-app-name
          repo_name: your-app-name
          repo_url: git@github.com:distributeaid/your-app-name.git
          infra_checkout_token: ${{ secrets.INFRA_CHECKOUT_TOKEN }}
          upcloud_token: ${{ secrets.UPCLOUD_TOKEN }}
          ansible_ssh_private_key: ${{ secrets.ANSIBLE_SSH_PRIVATE_KEY }}
          sops_age_key: ${{ secrets.SOPS_AGE_KEY }}
```
