### PR TITLE
fix: use actions/checkout@v6 and actions/setup-python@v6

### DIFF
--- a/.github/actions/ansible-deploy/action.yml
+++ b/.github/actions/ansible-deploy/action.yml
@@ -28,13 +28,13 @@ runs:
   using: "composite"
   steps:
     - name: Checkout infrastructure repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: distributeaid/infrastructure
         token: ${{ inputs.infra_checkout_token }}
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.12"
 


### PR DESCRIPTION
Corrects action versions that were incorrectly downgraded to v4/v5 — both v6 releases are the current latest.